### PR TITLE
Specify directory from which to run example scripts; add sample commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,13 @@ These examples should work with any recent version of JRuby, but we recommend in
 1. Install a JDK, if you don't already have one. JRuby 10 requires JDK 21+, JRuby 9.4 will work with JDK 8 (also known as 1.8).
 2. Install JRuby. Most Ruby installers know about JRuby, but there's also packages for major operating systems. You can also just download a JRuby tarball, unpack it, and put the `bin` dir in your `PATH`. It's that easy!
 3. Run `jruby -S lock_jars` from the root of this repository to fetch and install the JFreeChart library.
-4. Run any of the example scripts from the `examples` directory!
+4. Run any of the scripts in the `examples` directory from the root of this repository!
+
+For example, these commands run from the repository root directory will do the setup and run all the examples, outputting the generated graphs to that same directory:
+
+```bash
+jruby -S lock_jars
+jruby examples/category_chart.rb
+jruby examples/barchart.rb
+jruby examples/piechart.rb
+```


### PR DESCRIPTION
Hi, Charlie. Great illustration of how simple it is to use of JRuby to drive Java libraries!

When I tried the examples, I cd'ed into the examples directory and tried to run them from there. This did not work for category_chart.rb; I got the following error:

```
RuntimeError: 

	you might need to reinstall the gem which depends on the missing jar or in case there is Jars.lock then resolve the jars with `lock_jars` command

no such file to load -- org/jfree/org.jfree.pdf/2.0.1/org.jfree.pdf-2.0.1.jar (LoadError)
              do_require at /home/kbennett/.rvm/rubies/jruby-9.4.12.0/lib/ruby/stdlib/jar_dependencies.rb:359
             require_jar at /home/kbennett/.rvm/rubies/jruby-9.4.12.0/lib/ruby/stdlib/jar_dependencies.rb:268
  require_jar_with_block at /home/kbennett/.rvm/rubies/jruby-9.4.12.0/lib/ruby/stdlib/jar_dependencies.rb:312
             require_jar at /home/kbennett/.rvm/rubies/jruby-9.4.12.0/lib/ruby/stdlib/jar_dependencies.rb:267
             require_jar at /home/kbennett/.rvm/rubies/jruby-9.4.12.0/lib/ruby/stdlib/jar_dependencies.rb:369
                  <main> at ./category_chart.rb:70
LoadError: no such file to load -- org/jfree/org.jfree.pdf/2.0.1/org.jfree.pdf-2.0.1.jar
```

It comes from this line:

```ruby
require_jar 'org.jfree', 'org.jfree.pdf', '2.0.1'
```

So I figured it would be good to mention in the readme that the examples should be run from the project root. I also added some sample commands.
