### PR TITLE
Suggest cd into examples dir; assert precondition for running category_chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ These examples should work with any recent version of JRuby, but we recommend in
 
 1. Install a JDK, if you don't already have one. JRuby 10 requires JDK 21+, JRuby 9.4 will work with JDK 8 (also known as 1.8).
 2. Install JRuby. Most Ruby installers know about JRuby, but there's also packages for major operating systems. You can also just download a JRuby tarball, unpack it, and put the `bin` dir in your `PATH`. It's that easy!
-3. Run `jruby -S lock_jars` from the root of this repository to fetch and install the JFreeChart library.
-4. Run any of the scripts in the `examples` directory from the root of this repository!
+3. Change your working directory to be the `examples` directory and then run `jruby -S lock_jars` to fetch and install the JFreeChart library.
+4. Then run any of the scripts in the `examples` directory!
 
 For example, these commands run from the repository root directory will do the setup and run all the examples, outputting the generated graphs to that same directory:
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ These examples should work with any recent version of JRuby, but we recommend in
 For example, these commands run from the repository root directory will do the setup and run all the examples, outputting the generated graphs to that same directory:
 
 ```bash
+cd examples  # from the repository root directory
 jruby -S lock_jars
-jruby examples/category_chart.rb
-jruby examples/barchart.rb
-jruby examples/piechart.rb
+jruby category_chart.rb
+jruby barchart.rb
+jruby piechart.rb
 ```

--- a/examples/category_chart.rb
+++ b/examples/category_chart.rb
@@ -1,3 +1,16 @@
+def validate_environment
+  unless RUBY_ENGINE == 'jruby'
+    puts 'This example requires JRuby.'
+    exit 1
+  end
+  unless File.exist?('Jars.lock')
+    puts 'Jars.lock is missing, please run `jruby -S lock_jars`.'
+    exit 1
+  end
+end
+
+validate_environment
+
 require 'jar-dependencies'
 require_jar 'org.jfree', 'jfreechart', '1.5.5'
 require_jar 'org.jfree', 'org.jfree.chart3d', '2.1.0'
@@ -17,7 +30,8 @@ java_import org.jfree.chart3d.marker.CategoryMarker
 require 'json'
 
 dataset = StandardCategoryDataset3D.new
-data = JSON.load(File.read("data/app_monitoring_revenue.json"))
+data_filespec = File.absolute_path(File.join(File.dirname(__FILE__), '../data/app_monitoring_revenue.json'))
+data = JSON.load(File.read(data_filespec))
 data.each do |name, subset|
   values = DefaultKeyedValues.new
   subset.each { values.put(_1, _2) }

--- a/examples/category_chart.rb
+++ b/examples/category_chart.rb
@@ -1,15 +1,7 @@
-def validate_environment
-  unless RUBY_ENGINE == 'jruby'
-    puts 'This example requires JRuby.'
-    exit 1
-  end
-  unless File.exist?('Jars.lock')
-    puts 'Jars.lock is missing, please run `jruby -S lock_jars`.'
-    exit 1
-  end
+unless File.exist?('Jars.lock')
+  puts 'Jars.lock is missing, please run `jruby -S lock_jars`.'
+  exit 1
 end
-
-validate_environment
 
 require 'jar-dependencies'
 require_jar 'org.jfree', 'jfreechart', '1.5.5'


### PR DESCRIPTION
Since this code is largely intended to be an introduction to the JRuby experience, I thought that simplicity would be a very high priority. Towards this end, in the readme I suggested cd'ing into the 'examples' directory as a simplified approach, since it would eliminate the need to specify the directory when running the scripts. Also, it would remove ambiguity regarding the location of the `Jars.lock` file output by `jruby -S lock_jars`.

I also changed the data filespec location computation to be relative to `__FILE__` so that it will work regardless of which directory is the working directory at runtime (if, for example, the user chooses to run `jruby -S lock_jars` and the examples from a different directory).
